### PR TITLE
Add scan session tracking and file history

### DIFF
--- a/src/bluestash/cli.py
+++ b/src/bluestash/cli.py
@@ -5,25 +5,35 @@ This module provides a command-line interface for the BluStash file system index
 It allows users to scan directories and index their contents in a database through
 simple command-line commands.
 """
+
 import asyncio
 import os
 from pathlib import Path
 
 import typer
 from rich.console import Console
-from rich.progress import Progress, TextColumn, BarColumn, TaskProgressColumn, TimeElapsedColumn, MofNCompleteColumn, SpinnerColumn, TimeRemainingColumn
+from rich.progress import (
+    Progress,
+    TextColumn,
+    BarColumn,
+    TaskProgressColumn,
+    TimeElapsedColumn,
+    MofNCompleteColumn,
+    SpinnerColumn,
+    TimeRemainingColumn,
+)
 from rich.status import Status
 from sqlalchemy.exc import IntegrityError
 from dotenv import load_dotenv
 
-from bluestash.db.models import reg, engine
+from bluestash.db.models import reg, engine, ScanSession
 from bluestash.db.utils import (
     count_dirs_and_files,
     scan_dirs_and_build_lookup,
     insert_files_with_progress,
     get_async_session,
-    reset_all_valid_flags, # Importiert
-    delete_invalid_entries # Importiert
+    reset_all_valid_flags,  # Importiert
+    delete_invalid_entries,  # Importiert
 )
 from bluestash import setup_logging
 
@@ -37,6 +47,7 @@ logger = setup_logging(logger_name="bluestash.cli")
 app = typer.Typer(help="Ein CLI-Tool zur Verwaltung des Dateisystemindex.")
 console = Console()
 
+
 @app.command(name="scan")
 def scan_command(
     basis_pfad: Path = typer.Argument(
@@ -46,14 +57,14 @@ def scan_command(
         dir_okay=True,
         readable=True,
         resolve_path=True,
-        help="Der Basispfad, ab dem der Scan gestartet werden soll. Standardmäßig wird der Wert aus der .env-Datei verwendet."
+        help="Der Basispfad, ab dem der Scan gestartet werden soll. Standardmäßig wird der Wert aus der .env-Datei verwendet.",
     ),
     db_path: str = typer.Option(
         None,
         "--db-path",
         "-d",
-        help="Pfad zur Datenbank-Datei. Standardmäßig wird der Wert aus der .env-Datei verwendet."
-    )
+        help="Pfad zur Datenbank-Datei. Standardmäßig wird der Wert aus der .env-Datei verwendet.",
+    ),
 ):
     """
     Scan the file system starting from a given base path and index it in the database.
@@ -74,12 +85,14 @@ def scan_command(
     The base path for scanning can be provided as an argument. If not provided,
     the value from the FOLDER_ENTRYPOINT variable in the .env file will be used.
     """
+
     async def _scan():
         # If db_path is provided, set it as an environment variable
         if db_path:
             os.environ["DB_PATH"] = db_path
             # Re-import engine with the updated environment variable
             from bluestash.db.models import engine as updated_engine
+
             current_engine = updated_engine
         else:
             current_engine = engine
@@ -90,7 +103,11 @@ def scan_command(
             env_basis_pfad = os.getenv("FOLDER_ENTRYPOINT")
             if env_basis_pfad:
                 basis_pfad = Path(env_basis_pfad)
-                if not basis_pfad.exists() or not basis_pfad.is_dir() or not os.access(basis_pfad, os.R_OK):
+                if (
+                    not basis_pfad.exists()
+                    or not basis_pfad.is_dir()
+                    or not os.access(basis_pfad, os.R_OK)
+                ):
                     error_msg = f"Error: The path '{env_basis_pfad}' specified in the .env file does not exist, is not a directory, or is not readable."
                     console.print(f"[bold red]{error_msg}[/bold red]")
                     logger.error(error_msg)
@@ -122,16 +139,26 @@ def scan_command(
         # Use async context manager for database session
         async with get_async_session() as session:
             try:
+                scan_session = ScanSession()
+                session.add(scan_session)
+                await session.flush()
+
                 # Vor dem Scan: Alle is_valid-Flags auf False setzen
                 await reset_all_valid_flags(session)
-                console.print("[bold blue]Vorhandene Einträge auf Ungültig gesetzt.[/bold blue]")
+                console.print(
+                    "[bold blue]Vorhandene Einträge auf Ungültig gesetzt.[/bold blue]"
+                )
 
                 # PHASE 1: Initial Counting (Spinner)
                 logger.info("Counting directories and files...")
-                with console.status("[bold blue]Zähle Verzeichnisse und Dateien...", spinner="dots") as status:
+                with console.status(
+                    "[bold blue]Zähle Verzeichnisse und Dateien...", spinner="dots"
+                ) as status:
                     total_dirs, total_files = await count_dirs_and_files(basis_pfad)
                     status.update("[bold green]Zählung abgeschlossen.[/bold green]")
-                console.print(f"[bold green]Gefunden: {total_dirs} Verzeichnisse und {total_files} Dateien.[/bold green]")
+                console.print(
+                    f"[bold green]Gefunden: {total_dirs} Verzeichnisse und {total_files} Dateien.[/bold green]"
+                )
                 logger.info(f"Found: {total_dirs} directories and {total_files} files.")
 
                 # PHASE 2: Directory Scanning (Progress Bar)
@@ -144,24 +171,38 @@ def scan_command(
                     "eta",
                     TimeElapsedColumn(),
                     console=console,
-                    transient=False, # Bleibt sichtbar, bis explizit gestoppt/entfernt
+                    transient=False,  # Bleibt sichtbar, bis explizit gestoppt/entfernt
                 ) as progress_dir:
-                    dir_task = progress_dir.add_task("[cyan]Verzeichnisse scannen...", total=total_dirs)
+                    dir_task = progress_dir.add_task(
+                        "[cyan]Verzeichnisse scannen...", total=total_dirs
+                    )
                     logger.info("Scanning directories...")
 
                     def update_dir_progress(current_dirs: int, total: int):
                         progress_dir.update(dir_task, completed=current_dirs)
 
-                    dir_lookup = await scan_dirs_and_build_lookup(basis_pfad, session, total_dirs, progress_callback=update_dir_progress)
-                    progress_dir.update(dir_task, completed=total_dirs, description="[green]Verzeichnisse gescannt.[/green]")
-                    progress_dir.stop() # Beendet den Fortschrittsbalken für Verzeichnisse
+                    dir_lookup = await scan_dirs_and_build_lookup(
+                        basis_pfad,
+                        session,
+                        total_dirs,
+                        progress_callback=update_dir_progress,
+                    )
+                    progress_dir.update(
+                        dir_task,
+                        completed=total_dirs,
+                        description="[green]Verzeichnisse gescannt.[/green]",
+                    )
+                    progress_dir.stop()  # Beendet den Fortschrittsbalken für Verzeichnisse
                     logger.info("Directory scanning completed.")
 
                 # PHASE 3: Intermediate Spinner (Vorbereitung zur Dateiverarbeitung)
-                with console.status("[bold magenta]Bereite Dateiverarbeitung vor...", spinner="dots") as status:
-                    await asyncio.sleep(0.5) # Simuliert eine kurze Vorbereitungszeit
-                    status.update("[bold magenta]Vorbereitung abgeschlossen.[/bold magenta]")
-
+                with console.status(
+                    "[bold magenta]Bereite Dateiverarbeitung vor...", spinner="dots"
+                ) as status:
+                    await asyncio.sleep(0.5)  # Simuliert eine kurze Vorbereitungszeit
+                    status.update(
+                        "[bold magenta]Vorbereitung abgeschlossen.[/bold magenta]"
+                    )
 
                 # PHASE 4: File Processing (Progress Bar)
                 with Progress(
@@ -173,52 +214,74 @@ def scan_command(
                     "eta",
                     TimeElapsedColumn(),
                     console=console,
-                    transient=False, # Bleibt sichtbar, bis explizit gestoppt/entfernt
+                    transient=False,  # Bleibt sichtbar, bis explizit gestoppt/entfernt
                 ) as progress_file:
-                    file_task = progress_file.add_task("[yellow]Dateien verarbeiten...", total=total_files)
+                    file_task = progress_file.add_task(
+                        "[yellow]Dateien verarbeiten...", total=total_files
+                    )
                     logger.info("Processing files...")
 
                     def update_file_progress(current_files: int, total: int):
                         progress_file.update(file_task, completed=current_files)
 
-                    await insert_files_with_progress(session, dir_lookup, total_files, progress_callback=update_file_progress)
-                    progress_file.update(file_task, completed=total_files, description="[green]Dateien verarbeitet.[/green]")
-                    progress_file.stop() # Beendet den Fortschrittsbalken für Dateien
+                    processed = await insert_files_with_progress(
+                        session,
+                        dir_lookup,
+                        total_files,
+                        scan_session,
+                        progress_callback=update_file_progress,
+                    )
+                    scan_session.total_files = processed
+                    await session.flush()
+                    progress_file.update(
+                        file_task,
+                        completed=total_files,
+                        description="[green]Dateien verarbeitet.[/green]",
+                    )
+                    progress_file.stop()  # Beendet den Fortschrittsbalken für Dateien
                     logger.info("File processing completed.")
 
                 # Nach dem Scan: Ungültige Einträge löschen
-                #await delete_invalid_entries(session)
-                #console.print("[bold blue]Ungültige Einträge aus der Datenbank entfernt.[/bold blue]")
-
+                # await delete_invalid_entries(session)
+                # console.print("[bold blue]Ungültige Einträge aus der Datenbank entfernt.[/bold blue]")
 
                 # PHASE 5: Finalizing (Spinner)
                 logger.info("Finalizing database transactions...")
-                with console.status("[bold green]Finalisiere Datenbank-Transaktionen...", spinner="dots") as status:
+                with console.status(
+                    "[bold green]Finalisiere Datenbank-Transaktionen...", spinner="dots"
+                ) as status:
                     # Der commit wurde bereits in insert_files_with_progress nach jedem Chunk durchgeführt
                     # Ein finaler commit hier ist redundant, wenn alle Chunks committed wurden
                     # aber kann nicht schaden, falls noch pending changes vom Dir-Scan sind
                     await session.commit()
-                    status.update("[bold green]Datenbank-Transaktionen abgeschlossen.[/bold green]")
-                    await asyncio.sleep(0.5) # Simuliert eine kurze abschließende Verzögerung
+                    status.update(
+                        "[bold green]Datenbank-Transaktionen abgeschlossen.[/bold green]"
+                    )
+                    await asyncio.sleep(
+                        0.5
+                    )  # Simuliert eine kurze abschließende Verzögerung
                 logger.info("Database transactions completed.")
 
-                console.print("[bold green]Scan abgeschlossen, Datenbank ist aktuell.[/bold green]")
+                console.print(
+                    "[bold green]Scan abgeschlossen, Datenbank ist aktuell.[/bold green]"
+                )
                 logger.info("Scan completed, database is up to date.")
 
             except IntegrityError as e:
-                await session.rollback() # Rollback im Fehlerfall
+                await session.rollback()  # Rollback im Fehlerfall
                 error_msg = f"Integrity error (possibly duplicate entries): {e}"
                 console.print(f"[bold yellow]{error_msg}[/bold yellow]")
                 logger.error(error_msg)
                 raise typer.Exit(code=1)
             except Exception as e:
-                await session.rollback() # Rollback im Fehlerfall
+                await session.rollback()  # Rollback im Fehlerfall
                 error_msg = f"General error during scan: {e}"
                 console.print(f"[bold red]{error_msg}[/bold red]")
                 logger.error(error_msg, exc_info=True)
                 raise typer.Exit(code=1)
 
     asyncio.run(_scan())
+
 
 if __name__ == "__main__":
     app()

--- a/src/bluestash/db/models.py
+++ b/src/bluestash/db/models.py
@@ -10,17 +10,24 @@ Requirements:
 - Python ≥3.12
 - SQLAlchemy ≥2.0
 """
+
 from __future__ import annotations
 import os
 from pathlib import Path
+from datetime import datetime
+import uuid
 from sqlalchemy import (
-    BigInteger, Integer, String, LargeBinary, Boolean,
-    ForeignKey, Index,
+    BigInteger,
+    Integer,
+    String,
+    LargeBinary,
+    Boolean,
+    ForeignKey,
+    Index,
+    DateTime,
 )
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
-from sqlalchemy.orm import (
-    Mapped, mapped_column, relationship, registry
-)
+from sqlalchemy.orm import Mapped, mapped_column, relationship, registry
 from dotenv import load_dotenv
 
 from xxhash import xxh32_intdigest, xxh3_128_hexdigest
@@ -29,6 +36,27 @@ from xxhash import xxh32_intdigest, xxh3_128_hexdigest
 load_dotenv()
 
 reg = registry()
+
+
+@reg.mapped_as_dataclass()
+class ScanSession:
+    """Represents a single run of the BluStash scanner."""
+
+    __tablename__ = "scan_session"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
+    uuid: Mapped[str] = mapped_column(
+        String(36), unique=True, nullable=False, default=lambda: str(uuid.uuid4())
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
+    total_files: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    files: Mapped[list["File"]] = relationship(
+        back_populates="session", default_factory=list
+    )
+
 
 @reg.mapped_as_dataclass()
 class Dir:
@@ -42,20 +70,22 @@ class Dir:
     The model uses a self-referential relationship to represent the directory
     hierarchy, allowing for efficient traversal of the file system structure.
     """
+
     __tablename__ = "dir"
 
-    id: Mapped[int]      = mapped_column(Integer, primary_key=True, init=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
 
     # ── put *non-default* column first
-    name: Mapped[str]    = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
     full_path_hash: Mapped[int] = mapped_column(Integer, nullable=False)
-
 
     # ── defaulted columns may
     parent_id: Mapped[int | None] = mapped_column(
         ForeignKey("dir.id", ondelete="CASCADE"), default=None
     )
-    is_valid:Mapped[bool] = mapped_column(Boolean, default=True, nullable=False) # Hinzugefügt
+    is_valid: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False
+    )  # Hinzugefügt
 
     # self-referential relationship: use a lambda so Dir.id is defined
     parent: Mapped["Dir | None"] = relationship(
@@ -144,20 +174,31 @@ class File:
     The model uses xxHash128 for efficient content hashing, which allows for
     quick file identification and comparison.
     """
+
     __tablename__ = "file"
 
-    id:         Mapped[int]   = mapped_column(Integer, primary_key=True, init=False)
-    dir_id: Mapped[int] = mapped_column(ForeignKey("dir.id", ondelete="CASCADE"), init=False)
-    name:       Mapped[str]   = mapped_column(String, nullable=False)
-    size:       Mapped[int]   = mapped_column(BigInteger, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
+    dir_id: Mapped[int] = mapped_column(
+        ForeignKey("dir.id", ondelete="CASCADE"), init=False
+    )
+    session_id: Mapped[int] = mapped_column(
+        ForeignKey("scan_session.id", ondelete="CASCADE"), init=False
+    )
+    ancestor_id: Mapped[int | None] = mapped_column(ForeignKey("file.id"), default=None)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    size: Mapped[int] = mapped_column(BigInteger, nullable=False)
     hash_xx128: Mapped[bytes] = mapped_column(LargeBinary(16), nullable=False)
 
     dir: Mapped["Dir"] = relationship(back_populates="files")
+    session: Mapped["ScanSession"] = relationship(back_populates="files")
+    ancestor: Mapped["File | None"] = relationship(remote_side=lambda: File.id)
     is_safed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    is_valid:Mapped[bool] = mapped_column(Boolean, default=True, nullable=False) # Hinzugefügt
+    is_valid: Mapped[bool] = mapped_column(
+        Boolean, default=True, nullable=False
+    )  # Hinzugefügt
 
     __table_args__ = (
-        Index("ux_file_dir_name", "dir_id", "name", unique=True),
+        Index("ix_file_dir_name_session", "dir_id", "name", "session_id", unique=True),
     )
 
     @property
@@ -172,6 +213,7 @@ class File:
             Path: A Path object representing the absolute path of this file
         """
         return self.dir.full_path / self.name
+
 
 # ── async engine / session ───────────────────────────────────────────
 # Get database path from environment variable or use default


### PR DESCRIPTION
## Summary
- introduce `ScanSession` model to record each run with UUID and timestamp
- link files to sessions and keep history using optional ancestor reference
- update scanning utilities to create session records and handle file versioning
- adjust CLI to create a `ScanSession` each scan and record processed file count

## Testing
- `python -m py_compile src/bluestash/db/models.py src/bluestash/db/utils.py src/bluestash/cli.py`
- `black src/bluestash/db/models.py src/bluestash/db/utils.py src/bluestash/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684da0ea28348322952aadc39788d9aa